### PR TITLE
Add optional update checking on each launch of the application

### DIFF
--- a/ArtilleryCalculator/App.config
+++ b/ArtilleryCalculator/App.config
@@ -19,6 +19,15 @@
             <setting name="EnableClickTimer" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="LastIgnoredVersion" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="HasSelectedCheckForUpdatesPreference" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="ShouldCheckForUpdates" serializeAs="String">
+                <value>False</value>
+            </setting>
         </ArtilleryCalculator.Properties.Settings>
     </userSettings>
 </configuration>

--- a/ArtilleryCalculator/ArtilleryCalculator.csproj
+++ b/ArtilleryCalculator/ArtilleryCalculator.csproj
@@ -78,8 +78,12 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -100,9 +104,11 @@
       <DependentUpon>CalculatorForm.cs</DependentUpon>
     </Compile>
     <Compile Include="ClickListener.cs" />
+    <Compile Include="ArtilleryCalculatorApiClient.cs" />
     <Compile Include="NumpadListener.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UpdateChecker.cs" />
     <EmbeddedResource Include="CalculatorForm.resx">
       <DependentUpon>CalculatorForm.cs</DependentUpon>
     </EmbeddedResource>
@@ -116,6 +122,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/ArtilleryCalculator/ArtilleryCalculatorApiClient.cs
+++ b/ArtilleryCalculator/ArtilleryCalculatorApiClient.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+
+namespace ArtilleryCalculator
+{
+    class ArtilleryCalculatorApiClient
+    {
+        const string API_BASE_URL = "https://3kpt0s0jod.execute-api.us-east-1.amazonaws.com/dev";
+
+        protected HttpClient Client { get; }
+        protected JsonSerializer Serializer { get; } = new JsonSerializer()
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver()
+        };
+
+
+        public ArtilleryCalculatorApiClient(HttpClient httpClient)
+        {
+            Client = httpClient;
+        }
+
+        public async Task<LatestVersionInformation> GetLatestVersionInformation()
+        {
+            try
+            {
+                var currentVersion = this.GetType().Assembly.GetName().Version;
+                var url = $"{API_BASE_URL}/latest-version?version={currentVersion}";
+                var response = await Client.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+                var contentStream = await response.Content.ReadAsStreamAsync();
+
+                using (var streamReader = new StreamReader(contentStream))
+                using (var jsonReader = new JsonTextReader(streamReader))
+                {
+                    return Serializer.Deserialize<LatestVersionInformation>(jsonReader);
+                }
+            }
+            catch
+            {
+#if DEBUG
+                throw;
+#else
+                // Silently fail on purpose. I don't want this to ever prevent using the app
+                // and we do not have error reporting set up so this makes some sense.
+                return null;
+#endif
+            }
+        }
+
+        public class LatestVersionInformation
+        {
+            public bool Outdated { get; set; }
+            public string Version { get; set; }
+            public string Name { get; set; }
+            public string Body { get; set; }
+            public string Url { get; set; }
+            public DateTime PublishedAt { get; set; }
+        }
+    }
+}

--- a/ArtilleryCalculator/CalculatorForm.cs
+++ b/ArtilleryCalculator/CalculatorForm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using System.Windows.Forms;
 
 namespace ArtilleryCalculator
@@ -14,7 +15,7 @@ namespace ArtilleryCalculator
         DateTime LastNumpadInputAt { get; set; } = DateTime.MinValue;
         DateTime LastClickAt { get; set; } = DateTime.MinValue;
 
-        public CalculatorForm()
+        public CalculatorForm(HttpClient client)
         {
             InitializeComponent();
 
@@ -22,6 +23,9 @@ namespace ArtilleryCalculator
             enableNumpadCheckbox.Checked = Properties.Settings.Default.EnableNumpadListener;
             stayOnTopCheckbox.Checked = Properties.Settings.Default.StayOnTop;
             enableClickTimerCheckbox.Checked = Properties.Settings.Default.EnableClickTimer;
+
+            var updateChecker = new UpdateChecker(client);
+            updateChecker.InitializeUpdateChecking();
         }
 
         private void CalculatorForm_FormClosing(object sender, FormClosingEventArgs e)

--- a/ArtilleryCalculator/Program.cs
+++ b/ArtilleryCalculator/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using System.Windows.Forms;
 
 namespace ArtilleryCalculator
@@ -11,9 +12,11 @@ namespace ArtilleryCalculator
         [STAThread]
         static void Main()
         {
+            var httpClient = new HttpClient();
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new CalculatorForm());
+            Application.Run(new CalculatorForm(httpClient));
         }
     }
 }

--- a/ArtilleryCalculator/Properties/Settings.Designer.cs
+++ b/ArtilleryCalculator/Properties/Settings.Designer.cs
@@ -58,5 +58,41 @@ namespace ArtilleryCalculator.Properties {
                 this["EnableClickTimer"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LastIgnoredVersion {
+            get {
+                return ((string)(this["LastIgnoredVersion"]));
+            }
+            set {
+                this["LastIgnoredVersion"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HasSelectedCheckForUpdatesPreference {
+            get {
+                return ((bool)(this["HasSelectedCheckForUpdatesPreference"]));
+            }
+            set {
+                this["HasSelectedCheckForUpdatesPreference"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShouldCheckForUpdates {
+            get {
+                return ((bool)(this["ShouldCheckForUpdates"]));
+            }
+            set {
+                this["ShouldCheckForUpdates"] = value;
+            }
+        }
     }
 }

--- a/ArtilleryCalculator/Properties/Settings.settings
+++ b/ArtilleryCalculator/Properties/Settings.settings
@@ -11,5 +11,14 @@
     <Setting Name="EnableClickTimer" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="LastIgnoredVersion" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="HasSelectedCheckForUpdatesPreference" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ShouldCheckForUpdates" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ArtilleryCalculator/UpdateChecker.cs
+++ b/ArtilleryCalculator/UpdateChecker.cs
@@ -1,0 +1,91 @@
+﻿using System.Diagnostics;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ArtilleryCalculator
+{
+    class UpdateChecker
+    {
+        ArtilleryCalculatorApiClient ApiClient { get; }
+
+        public UpdateChecker(HttpClient httpClient)
+        {
+            ApiClient = new ArtilleryCalculatorApiClient(httpClient);
+        }
+
+        public void InitializeUpdateChecking()
+        {
+            if (!Properties.Settings.Default.HasSelectedCheckForUpdatesPreference)
+            {
+                PromptUserForUpdateChecks();
+            }
+
+            if (Properties.Settings.Default.ShouldCheckForUpdates)
+            {
+                CheckForUpdates();
+            }
+        }
+
+        void PromptUserForUpdateChecks()
+        {
+            var caption = "Automatically check for updates";
+            var text = "Do you want the application to automatically check for updates when you open it?\r\n\r\nIf you select yes, you will see a message box like this one whenever new updates of Artillery Calculator are published.";
+            var result = MessageBox.Show(text, caption, MessageBoxButtons.YesNo);
+
+            if (result == DialogResult.Yes)
+            {
+                Properties.Settings.Default.ShouldCheckForUpdates = true;
+                Properties.Settings.Default.HasSelectedCheckForUpdatesPreference = true;
+            }
+            else if (result == DialogResult.No)
+            {
+                Properties.Settings.Default.ShouldCheckForUpdates = false;
+                Properties.Settings.Default.HasSelectedCheckForUpdatesPreference = true;
+            }
+        }
+
+        void CheckForUpdates()
+        {
+            SynchronizationContext context = SynchronizationContext.Current;
+
+            Task.Run(async () =>
+            {
+                var info = await ApiClient.GetLatestVersionInformation();
+                if (info?.Outdated ?? false)
+                {
+                    context.Post(new SendOrPostCallback((state) =>
+                    {
+                        if (!IsVersionAlreadyIgnored(info.Version))
+                        {
+                            PromptUserToUpdateIfNotIgnored(info);
+                        }
+                    }), null);
+                }
+            });
+        }
+
+        bool IsVersionAlreadyIgnored(string version)
+        {
+            var lastIgnoredVersion = Properties.Settings.Default.LastIgnoredVersion;
+            return !string.IsNullOrEmpty(lastIgnoredVersion) || lastIgnoredVersion == version;
+        }
+
+        void PromptUserToUpdateIfNotIgnored(ArtilleryCalculatorApiClient.LatestVersionInformation info)
+        {
+            var caption = info.Name;
+            var text = $"A new version of Artillery Calculator is available. Do you want to open your browser to download it now?\r\n\r\nIf you select no, you won't be reminded until the next release.";
+            var result = MessageBox.Show(text, caption, MessageBoxButtons.YesNo);
+
+            if (result == DialogResult.Yes)
+            {
+                Process.Start(info.Url);
+            }
+            else if (result == DialogResult.No)
+            {
+                Properties.Settings.Default.LastIgnoredVersion = info.Version;
+            }
+        }
+    }
+}

--- a/ArtilleryCalculator/packages.config
+++ b/ArtilleryCalculator/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
This new feature uses a simple API powered by AWS Lambda that checks
the Github project for a newer release than the current one which is
passed as a query parameter. It returns some information about the
version so some of it can be displayed to user and the URL for that
release can be opened if wanted.

Resolves #2